### PR TITLE
Reduced jumping between depths during raymarching iteration

### DIFF
--- a/examples/bevy_wgpu_render.rs
+++ b/examples/bevy_wgpu_render.rs
@@ -90,7 +90,7 @@ fn setup(
             }
         }
     }
-    let quad_count = 2;
+    let quad_count = 1;
     let quad_size = 10. / quad_count as f32;
     let mesh_handle = meshes.add(Mesh::from(Rectangle {
         half_size: Vec2::new(quad_size, quad_size) / 2.,


### PR DESCRIPTION
To reduce global RAM reads in GPU, and to prepare for bitmasks optimization, ray iteration advance part is updated to check for the sibling targets being empty, before pushing the iteration into it. 

Introduced a loop checking if the target node is empty and advancing the iteration forward until either 

- Target child node is out of bounds of the current parent 
- The target child node Is not empty

As a result iteration is smarter by checking forward to see if the next target child is a valid candidate for iteration. 

By combining this modification with #21 there is potential for increased raytracing performance.


Original algorithm was based on: https://research.nvidia.com/sites/default/files/pubs/2010-02_Efficient-Sparse-Voxel/laine2010tr1_paper.pdf