### PR TITLE
Resolves #41 - Implementation of a raw wgpu pipeline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 default = []
 raytracing = ["dep:image", "dep:show-image"]
 serialization = ["dep:serde"]
-wgpu = ["raytracing", "dep:bytemuck","dep:wgpu", "dep:winit", "dep:env_logger", "dep:futures"]
+wgpu = ["raytracing", "dep:encase","dep:wgpu", "dep:winit", "dep:env_logger", "dep:futures"]
 bevy_wgpu = ["raytracing", "dep:bevy"]
 
 [dependencies]
@@ -20,7 +20,7 @@ wgpu = { version = "0.20.1", optional = true }
 winit = { version = "0.30.3", optional = true }
 env_logger = { version = "0.11.3", optional = true }
 futures = { version = "0.3.30", optional = true }
-bytemuck = { version = "1.16.1", features = ["derive"], optional = true }
+encase = { version = "0.9.0", optional = true }
 
 # for example cpu_render
 image = { version = "0.25.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 default = []
 raytracing = ["dep:image", "dep:show-image"]
 serialization = ["dep:serde"]
-wgpu = ["raytracing", "dep:wgpu", "dep:winit", "dep:env_logger", "dep:futures"]
+wgpu = ["raytracing", "dep:bytemuck","dep:wgpu", "dep:winit", "dep:env_logger", "dep:futures"]
 bevy_wgpu = ["raytracing", "dep:bevy"]
 
 [dependencies]
@@ -20,6 +20,7 @@ wgpu = { version = "0.20.1", optional = true }
 winit = { version = "0.30.3", optional = true }
 env_logger = { version = "0.11.3", optional = true }
 futures = { version = "0.3.30", optional = true }
+bytemuck = { version = "1.16.1", features = ["derive"], optional = true }
 
 # for example cpu_render
 image = { version = "0.25.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,18 @@ license = "MIT OR Apache-2.0"
 default = []
 raytracing = ["dep:image", "dep:show-image"]
 serialization = ["dep:serde"]
-bevy_wgpu = ["dep:bevy", "raytracing"]
+wgpu = ["raytracing", "dep:wgpu", "dep:winit", "dep:env_logger", "dep:futures"]
+bevy_wgpu = ["raytracing", "dep:bevy"]
 
 [dependencies]
 serde = { version = "1.0.183", features = ["derive"], optional = true }
 bendy = { git = "https://github.com/davids91/bendy.git" , features = ["std", "serde"]}
 array-init = "2.1.0"
+wgpu = { version = "0.20.1", optional = true }
+winit = { version = "0.30.3", optional = true }
+env_logger = { version = "0.11.3", optional = true }
+futures = { version = "0.3.30", optional = true }
+
 # for example cpu_render
 image = { version = "0.25.1", optional = true }
 show-image = { version = "0.14.0", optional = true }

--- a/assets/shaders/bevy_viewport_render.wgsl
+++ b/assets/shaders/bevy_viewport_render.wgsl
@@ -686,6 +686,8 @@ fn update(
     textureStore(output_texture, pixel_location, vec4f(rgb_result, 1.));
 }
 
+
+
 // Note: should be const
 var<private> OCTANT_STEP_RESULT_LUT: array<array<array<u32, 3>, 3>, 3> = array<array<array<u32, 3>, 3>, 3>(
     array<array<u32, 3>, 3>(

--- a/examples/wgpu_render.rs
+++ b/examples/wgpu_render.rs
@@ -1,11 +1,75 @@
 use shocovox_rs::octree::raytracing::wgpu::SvxRenderApp;
+use shocovox_rs::octree::Albedo;
+use shocovox_rs::octree::V3c;
+use std::sync::Arc;
 use winit::event_loop::{ControlFlow, EventLoop};
 
+#[cfg(feature = "wgpu")]
+const DISPLAY_RESOLUTION: [u32; 2] = [1024, 768];
+
+#[cfg(feature = "wgpu")]
+const ARRAY_DIMENSION: u32 = 128;
+
+#[cfg(feature = "wgpu")]
 fn main() {
     let event_loop = EventLoop::new().unwrap();
     env_logger::init();
     event_loop.set_control_flow(ControlFlow::Poll);
 
-    let mut app = SvxRenderApp::new(1024, 768);
+    let mut app = SvxRenderApp::new(DISPLAY_RESOLUTION[0], DISPLAY_RESOLUTION[1]);
+
+    // fill octree with data
+    let mut tree = shocovox_rs::octree::Octree::<Albedo, 16>::new(ARRAY_DIMENSION)
+        .ok()
+        .unwrap();
+
+    tree.insert(&V3c::new(1, 3, 3), Albedo::from(0x66FFFF))
+        .ok()
+        .unwrap();
+    for x in 0..ARRAY_DIMENSION {
+        for y in 0..ARRAY_DIMENSION {
+            for z in 0..ARRAY_DIMENSION {
+                if ((x < (ARRAY_DIMENSION / 4)
+                    || y < (ARRAY_DIMENSION / 4)
+                    || z < (ARRAY_DIMENSION / 4))
+                    && (0 == x % 2 && 0 == y % 4 && 0 == z % 2))
+                    || ((ARRAY_DIMENSION / 2) <= x
+                        && (ARRAY_DIMENSION / 2) <= y
+                        && (ARRAY_DIMENSION / 2) <= z)
+                {
+                    let r = if 0 == x % (ARRAY_DIMENSION / 4) {
+                        (x as f32 / ARRAY_DIMENSION as f32 * 255.) as u32
+                    } else {
+                        128
+                    };
+                    let g = if 0 == y % (ARRAY_DIMENSION / 4) {
+                        (y as f32 / ARRAY_DIMENSION as f32 * 255.) as u32
+                    } else {
+                        128
+                    };
+                    let b = if 0 == z % (ARRAY_DIMENSION / 4) {
+                        (z as f32 / ARRAY_DIMENSION as f32 * 255.) as u32
+                    } else {
+                        128
+                    };
+                    tree.insert(
+                        &V3c::new(x, y, z),
+                        Albedo::from(r | (g << 8) | (b << 16) | 0xFF000000),
+                    )
+                    .ok()
+                    .unwrap();
+                }
+            }
+        }
+    }
+
+    let showcase = Arc::new(tree);
+    showcase.upload_to(&mut app);
     let _ = event_loop.run_app(&mut app);
+}
+
+#[cfg(not(feature = "wgpu"))]
+fn main() {
+    println!("You probably forgot to enable the wgpu feature!");
+    //nothing to do when the feature is not enabled
 }

--- a/examples/wgpu_render.rs
+++ b/examples/wgpu_render.rs
@@ -1,0 +1,11 @@
+use shocovox_rs::octree::raytracing::wgpu::SvxRenderApp;
+use winit::event_loop::{ControlFlow, EventLoop};
+
+fn main() {
+    let event_loop = EventLoop::new().unwrap();
+    env_logger::init();
+    event_loop.set_control_flow(ControlFlow::Poll);
+
+    let mut app = SvxRenderApp::new(1024, 768);
+    let _ = event_loop.run_app(&mut app);
+}

--- a/examples/wgpu_render.rs
+++ b/examples/wgpu_render.rs
@@ -63,8 +63,9 @@ fn main() {
         }
     }
 
+    std::env::set_var("RUST_BACKTRACE", "1");
     let showcase = Arc::new(tree);
-    showcase.upload_to(&mut app);
+    //showcase.upload_to(&mut app);
     let _ = event_loop.run_app(&mut app);
 }
 

--- a/src/octree/bytecode.rs
+++ b/src/octree/bytecode.rs
@@ -8,37 +8,37 @@ use bendy::{
 impl<'obj, 'ser, T: Clone + VoxelData, const DIM: usize> NodeContent<T, DIM> {
     fn encode_single(data: &T, encoder: &mut Encoder) -> Result<(), BencodeError> {
         let color = data.albedo();
-        encoder.emit(color.r)?;
-        encoder.emit(color.g)?;
-        encoder.emit(color.b)?;
-        encoder.emit(color.a)?;
+        encoder.emit((color.r * 1000.) as i32)?;
+        encoder.emit((color.g * 1000.) as i32)?;
+        encoder.emit((color.b * 1000.) as i32)?;
+        encoder.emit((color.a * 1000.) as i32)?;
         encoder.emit(data.user_data())
     }
 
     fn decode_single(list: &mut ListDecoder<'obj, 'ser>) -> Result<T, bendy::decoding::Error> {
         let r = match list.next_object()?.unwrap() {
-            Object::Integer(i) => Ok(i.parse::<u8>().ok().unwrap()),
+            Object::Integer(i) => Ok(i.parse::<i32>().ok().unwrap()),
             _ => Err(bendy::decoding::Error::unexpected_token(
                 "int field red color component",
                 "Something else",
             )),
         }?;
         let g = match list.next_object()?.unwrap() {
-            Object::Integer(i) => Ok(i.parse::<u8>().ok().unwrap()),
+            Object::Integer(i) => Ok(i.parse::<i32>().ok().unwrap()),
             _ => Err(bendy::decoding::Error::unexpected_token(
                 "int field green color component",
                 "Something else",
             )),
         }?;
         let b = match list.next_object()?.unwrap() {
-            Object::Integer(i) => Ok(i.parse::<u8>().ok().unwrap()),
+            Object::Integer(i) => Ok(i.parse::<i32>().ok().unwrap()),
             _ => Err(bendy::decoding::Error::unexpected_token(
                 "int field blue color component",
                 "Something else",
             )),
         }?;
         let a = match list.next_object()?.unwrap() {
-            Object::Integer(i) => Ok(i.parse::<u8>().ok().unwrap()),
+            Object::Integer(i) => Ok(i.parse::<i32>().ok().unwrap()),
             _ => Err(bendy::decoding::Error::unexpected_token(
                 "int field alpha color component",
                 "Something else",
@@ -49,10 +49,10 @@ impl<'obj, 'ser, T: Clone + VoxelData, const DIM: usize> NodeContent<T, DIM> {
             _ => 0,
         };
         let albedo = Albedo::default()
-            .with_red(r)
-            .with_green(g)
-            .with_blue(b)
-            .with_alpha(a);
+            .with_red(r as f32 / 1000.)
+            .with_green(g as f32 / 1000.)
+            .with_blue(b as f32 / 1000.)
+            .with_alpha(a as f32 / 1000.);
         Ok(VoxelData::new(albedo, user_data))
     }
 }

--- a/src/octree/detail.rs
+++ b/src/octree/detail.rs
@@ -94,7 +94,7 @@ where
         }
     }
 
-    #[cfg(feature = "bevy_wgpu")]
+    #[cfg(any(feature = "bevy_wgpu", feature = "wgpu"))]
     pub(in crate::octree) fn get_full(&self) -> [T; 8] {
         match &self.content {
             NodeChildrenArray::Children(c) => c.clone(),

--- a/src/octree/raytracing/bevy/mod.rs
+++ b/src/octree/raytracing/bevy/mod.rs
@@ -39,7 +39,7 @@ impl FromWorld for ShocoVoxRenderPipeline {
             ShocoVoxViewingGlass::bind_group_layout(render_device);
         let shader = world
             .resource::<AssetServer>()
-            .load("shaders/viewport_render.wgsl");
+            .load("shaders/bevy_viewport_render.wgsl");
         let pipeline_cache = world.resource::<PipelineCache>();
         let update_pipeline = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
             label: None,

--- a/src/octree/raytracing/mod.rs
+++ b/src/octree/raytracing/mod.rs
@@ -4,6 +4,9 @@ mod tests;
 #[cfg(feature = "bevy_wgpu")]
 pub mod bevy;
 
+#[cfg(feature = "wgpu")]
+pub mod wgpu;
+
 pub use crate::spatial::raytracing::Ray;
 
 #[cfg(feature = "bevy_wgpu")]

--- a/src/octree/raytracing/wgpu/data.rs
+++ b/src/octree/raytracing/wgpu/data.rs
@@ -1,0 +1,260 @@
+use std::num::NonZero;
+
+use crate::octree::{
+    empty_marker, raytracing::wgpu::types::Voxelement, types::NodeChildrenArray, NodeContent,
+    Octree, VoxelData,
+};
+use wgpu::util::DeviceExt;
+
+use super::{
+    types::{OctreeMetaData, SizedNode},
+    SvxRenderApp,
+};
+
+impl<T, const DIM: usize> From<&Octree<T, DIM>> for OctreeMetaData
+where
+    T: Default + Clone + VoxelData,
+{
+    fn from(tree: &Octree<T, DIM>) -> Self {
+        OctreeMetaData {
+            octree_size: tree.octree_size,
+            voxel_brick_dim: DIM as u32,
+            ambient_light_color: [1., 1., 1.],
+            ambient_light_position: [DIM as f32, DIM as f32, DIM as f32],
+        }
+    }
+}
+
+impl SvxRenderApp {
+    //    fn
+}
+
+impl<T, const DIM: usize> Octree<T, DIM>
+where
+    T: Default + Clone + VoxelData,
+{
+    fn meta_set_is_leaf(sized_node_meta: &mut u32, is_leaf: bool) {
+        *sized_node_meta =
+            (*sized_node_meta & 0x00FFFFFF) | if is_leaf { 0x01000000 } else { 0x00000000 };
+    }
+
+    fn meta_set_node_occupancy_bitmap(sized_node_meta: &mut u32, bitmap: u8) {
+        *sized_node_meta = (*sized_node_meta & 0xFFFFFF00) | bitmap as u32;
+    }
+
+    fn create_meta(&self, node_key: usize) -> u32 {
+        let node = self.nodes.get(node_key);
+        let mut meta = 0;
+        match node {
+            NodeContent::Leaf(_) => {
+                Self::meta_set_is_leaf(&mut meta, true);
+                Self::meta_set_node_occupancy_bitmap(
+                    &mut meta,
+                    self.occupied_8bit(node_key as u32),
+                );
+            }
+            NodeContent::Internal(occupied_bits) => {
+                Self::meta_set_is_leaf(&mut meta, false);
+                Self::meta_set_node_occupancy_bitmap(&mut meta, *occupied_bits);
+            }
+            _ => {
+                Self::meta_set_is_leaf(&mut meta, false);
+                Self::meta_set_node_occupancy_bitmap(&mut meta, 0x00);
+            }
+        };
+        meta
+    }
+
+    pub fn upload_to(&self, app: &mut SvxRenderApp) {
+        // parse octree
+        let mut nodes = Vec::new();
+        let mut children = Vec::new();
+        let mut voxels = Vec::new();
+
+        for i in 0..self.nodes.len() {
+            if !self.nodes.key_is_valid(i) {
+                continue;
+            }
+            let mut sized_node = SizedNode {
+                sized_node_meta: self.create_meta(i),
+                children_start_at: children.len() as u32,
+                voxels_start_at: empty_marker(),
+            };
+            if let NodeContent::Leaf(data) = self.nodes.get(i) {
+                debug_assert!(matches!(
+                    self.node_children[i].content,
+                    NodeChildrenArray::OccupancyBitmap(_)
+                ));
+                let occupied_bits = match self.node_children[i].content {
+                    NodeChildrenArray::OccupancyBitmap(bitmap) => bitmap,
+                    _ => panic!("Found Leaf Node without occupancy bitmap!"),
+                };
+                children.extend_from_slice(&[
+                    (occupied_bits & 0x00000000FFFFFFFF) as u32,
+                    ((occupied_bits & 0xFFFFFFFF00000000) >> 32) as u32,
+                ]);
+                sized_node.voxels_start_at = voxels.len() as u32;
+                for z in 0..DIM {
+                    for y in 0..DIM {
+                        for x in 0..DIM {
+                            let albedo = data[x][y][z].albedo();
+                            let content = data[x][y][z].user_data();
+                            voxels.push(Voxelement {
+                                albedo: [
+                                    albedo.r as f32 / 255.,
+                                    albedo.g as f32 / 255.,
+                                    albedo.b as f32 / 255.,
+                                    albedo.a as f32 / 255.,
+                                ],
+                                content,
+                            })
+                        }
+                    }
+                }
+            } else {
+                //Internal nodes
+                children.extend_from_slice(&self.node_children[i].get_full());
+            }
+            nodes.push(sized_node);
+        }
+
+        debug_assert!(0 < nodes.len());
+        debug_assert!(0 < children.len());
+        debug_assert!(0 < voxels.len());
+
+        // Create bind group layout
+        let layout = app
+            .device
+            .as_ref()
+            .expect("Expected Render Device")
+            .create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                entries: &[
+                    // metadata
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::COMPUTE,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Uniform,
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: None,
+                    },
+                    // nodes
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::COMPUTE,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Storage { read_only: true },
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: Some(NonZero::new(nodes.len() as u32).unwrap()),
+                    },
+                    // children
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 2,
+                        visibility: wgpu::ShaderStages::COMPUTE,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Storage { read_only: true },
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: Some(NonZero::new(children.len() as u32).unwrap()),
+                    },
+                    // voxels
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 3,
+                        visibility: wgpu::ShaderStages::COMPUTE,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Storage { read_only: true },
+                            has_dynamic_offset: false,
+                            min_binding_size: None,
+                        },
+                        count: Some(NonZero::new(voxels.len() as u32).unwrap()),
+                    },
+                ],
+                label: Some("Octree_Layout"),
+            });
+
+        // Upload data to buffers
+        let octree_meta = OctreeMetaData::from(self);
+        let metadata_buffer = app
+            .device
+            .as_ref()
+            .expect("Expected SvxRenderApp to have a vaild device!")
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("Octree Metadata Buffer"),
+                contents: bytemuck::cast_slice(&[octree_meta]),
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            });
+        let nodes_buffer = app
+            .device
+            .as_ref()
+            .expect("Expected SvxRenderApp to have a vaild device!")
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("Octree Metadata Buffer"),
+                contents: &bytemuck::try_cast_vec(nodes).ok().unwrap(),
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            });
+        let children_buffer = app
+            .device
+            .as_ref()
+            .expect("Expected SvxRenderApp to have a vaild device!")
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("Octree Metadata Buffer"),
+                contents: &bytemuck::try_cast_vec(children).ok().unwrap(),
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            });
+        let voxels_buffer = app
+            .device
+            .as_ref()
+            .expect("Expected SvxRenderApp to have a vaild device!")
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some("Octree Metadata Buffer"),
+                contents: &bytemuck::try_cast_vec(voxels).ok().unwrap(),
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            });
+
+        // Create bind group
+        let group = app
+            .device
+            .as_ref()
+            .expect("Expected SvxRenderApp to have a vaild device!")
+            .create_bind_group(&wgpu::BindGroupDescriptor {
+                layout: &layout,
+                entries: &[
+                    // wgpu::BindGroupEntry {
+                    //     binding: 0,
+                    //     resource: ??.as_entire_binding(),
+                    // },
+                    wgpu::BindGroupEntry {
+                        binding: 0,
+                        resource: metadata_buffer.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 1,
+                        resource: nodes_buffer.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 2,
+                        resource: children_buffer.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 3,
+                        resource: voxels_buffer.as_entire_binding(),
+                    },
+                ],
+                label: Some("camera_bind_group"),
+            });
+        let render_pipeline_layout = app
+            .device
+            .as_ref()
+            .expect("Expected SvxRenderApp to have a vaild device!")
+            .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("Render Pipeline Layout"),
+                bind_group_layouts: &[&layout],
+                push_constant_ranges: &[],
+            });
+    }
+}

--- a/src/octree/raytracing/wgpu/mod.rs
+++ b/src/octree/raytracing/wgpu/mod.rs
@@ -1,0 +1,201 @@
+use std::{borrow::Cow, sync::Arc};
+use wgpu::{Adapter, Device, Queue, RenderPipeline, Surface};
+use winit::{
+    application::ApplicationHandler,
+    event::WindowEvent,
+    event_loop::ActiveEventLoop,
+    window::{Window, WindowId},
+};
+
+pub struct SvxRenderApp {
+    output_width: u32,
+    output_height: u32,
+    wgpu_instance: wgpu::Instance,
+    adapter: Option<Adapter>,
+    window: Option<Arc<Window>>,
+    surface: Option<Surface<'static>>,
+    device: Option<Device>,
+    pipeline: Option<RenderPipeline>,
+    queue: Option<Queue>,
+}
+
+impl SvxRenderApp {
+    async fn rebuild_pipeline(&mut self) {
+        assert!(self.window.is_some());
+        let surface = self
+            .wgpu_instance
+            .create_surface(self.window.as_ref().unwrap().clone())
+            .unwrap();
+
+        let adapter = self
+            .wgpu_instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::default(),
+                force_fallback_adapter: false,
+                // Request an adapter which can render to our surface
+                compatible_surface: Some(&surface),
+            })
+            .await
+            .expect("Failed to find an appropriate adapter");
+
+        let (device, queue) = adapter
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    label: None,
+                    required_features: wgpu::Features::empty(),
+                    // Make sure we use the texture resolution limits from the adapter, so we can support images the size of the swapchain.
+                    required_limits: wgpu::Limits::downlevel_webgl2_defaults()
+                        .using_resolution(adapter.limits()),
+                },
+                None,
+            )
+            .await
+            .expect("Failed to create device");
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: None,
+            bind_group_layouts: &[],
+            push_constant_ranges: &[],
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: None,
+            source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!("raytracing.wgsl"))),
+        });
+
+        let swapchain_capabilities = surface.get_capabilities(&adapter);
+        let swapchain_format = swapchain_capabilities.formats[0];
+        self.pipeline = Some(
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: None,
+                layout: Some(&pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: "vs_main",
+                    buffers: &[],
+                    compilation_options: Default::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: "fs_main",
+                    compilation_options: Default::default(),
+                    targets: &[Some(swapchain_format.into())],
+                }),
+                primitive: wgpu::PrimitiveState::default(),
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview: None,
+            }),
+        );
+
+        let config = surface
+            .get_default_config(&adapter, self.output_width, self.output_height)
+            .unwrap();
+        surface.configure(&device, &config);
+
+        self.adapter = Some(adapter);
+        self.surface = Some(surface);
+        self.queue = Some(queue);
+        self.device = Some(device);
+    }
+
+    pub fn new(output_width: u32, output_height: u32) -> Self {
+        let wgpu_instance = wgpu::Instance::default();
+        // for adapter in wgpu_instance.enumerate_adapters(wgpu::Backends::all()) {
+        //     println!("{:?}", adapter.get_info())
+        // }
+
+        Self {
+            wgpu_instance,
+            output_width,
+            output_height,
+            window: None,
+            adapter: None,
+            surface: None,
+            device: None,
+            pipeline: None,
+            queue: None,
+        }
+    }
+}
+
+impl ApplicationHandler for SvxRenderApp {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        self.window = Some(Arc::new(
+            event_loop
+                .create_window(
+                    Window::default_attributes()
+                        .with_title("Voxel Raytracing Render")
+                        .with_inner_size(winit::dpi::PhysicalSize::new(
+                            self.output_width,
+                            self.output_height,
+                        )),
+                )
+                .unwrap(),
+        ));
+        futures::executor::block_on(self.rebuild_pipeline())
+    }
+
+    fn window_event(&mut self, event_loop: &ActiveEventLoop, _id: WindowId, event: WindowEvent) {
+        match event {
+            WindowEvent::CloseRequested => {
+                event_loop.exit();
+            }
+            WindowEvent::RedrawRequested => {
+                if self.window.is_none() {
+                    return;
+                }
+                let mut size = self.window.as_ref().unwrap().inner_size();
+                size.width = size.width.max(1);
+                size.height = size.height.max(1);
+
+                let frame = self
+                    .surface
+                    .as_ref()
+                    .expect("Render Surface not available")
+                    .get_current_texture()
+                    .expect("Failed to acquire next swap chain texture");
+
+                let view = frame
+                    .texture
+                    .create_view(&wgpu::TextureViewDescriptor::default());
+                let mut encoder = self
+                    .device
+                    .as_ref()
+                    .expect("Device Encoder not found")
+                    .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+                {
+                    let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                        label: None,
+                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                            view: &view,
+                            resolve_target: None, //render target!
+                            ops: wgpu::Operations {
+                                load: wgpu::LoadOp::Clear(wgpu::Color::GREEN),
+                                store: wgpu::StoreOp::Store,
+                            },
+                        })],
+                        depth_stencil_attachment: None,
+                        timestamp_writes: None,
+                        occlusion_query_set: None,
+                    });
+                    rpass.set_pipeline(&self.pipeline.as_ref().unwrap());
+                    rpass.draw(0..6, 0..1);
+                }
+
+                self.queue
+                    .as_ref()
+                    .expect("Render Queue not available")
+                    .submit(Some(encoder.finish()));
+                frame.present();
+
+                self.window.as_ref().unwrap().request_redraw();
+            }
+            WindowEvent::Resized(size) => {
+                self.output_width = size.width;
+                self.output_height = size.height;
+                futures::executor::block_on(self.rebuild_pipeline())
+            }
+            _ => (),
+        }
+    }
+}

--- a/src/octree/raytracing/wgpu/mod.rs
+++ b/src/octree/raytracing/wgpu/mod.rs
@@ -1,201 +1,46 @@
-use std::{borrow::Cow, sync::Arc};
-use wgpu::{Adapter, Device, Queue, RenderPipeline, Surface};
-use winit::{
-    application::ApplicationHandler,
-    event::WindowEvent,
-    event_loop::ActiveEventLoop,
-    window::{Window, WindowId},
-};
+mod data;
+mod pipeline;
+mod render;
+mod types;
 
-pub struct SvxRenderApp {
-    output_width: u32,
-    output_height: u32,
-    wgpu_instance: wgpu::Instance,
-    adapter: Option<Adapter>,
-    window: Option<Arc<Window>>,
-    surface: Option<Surface<'static>>,
-    device: Option<Device>,
-    pipeline: Option<RenderPipeline>,
-    queue: Option<Queue>,
-}
+pub use crate::octree::raytracing::wgpu::types::{SvxRenderApp, Viewport};
+use crate::octree::Octree;
+use std::sync::Arc;
+
+use wgpu::util::DeviceExt;
 
 impl SvxRenderApp {
-    async fn rebuild_pipeline(&mut self) {
-        assert!(self.window.is_some());
-        let surface = self
-            .wgpu_instance
-            .create_surface(self.window.as_ref().unwrap().clone())
-            .unwrap();
-
-        let adapter = self
-            .wgpu_instance
-            .request_adapter(&wgpu::RequestAdapterOptions {
-                power_preference: wgpu::PowerPreference::default(),
-                force_fallback_adapter: false,
-                // Request an adapter which can render to our surface
-                compatible_surface: Some(&surface),
-            })
-            .await
-            .expect("Failed to find an appropriate adapter");
-
-        let (device, queue) = adapter
-            .request_device(
-                &wgpu::DeviceDescriptor {
-                    label: None,
-                    required_features: wgpu::Features::empty(),
-                    // Make sure we use the texture resolution limits from the adapter, so we can support images the size of the swapchain.
-                    required_limits: wgpu::Limits::downlevel_webgl2_defaults()
-                        .using_resolution(adapter.limits()),
-                },
-                None,
-            )
-            .await
-            .expect("Failed to create device");
-        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-            label: None,
-            bind_group_layouts: &[],
-            push_constant_ranges: &[],
-        });
-
-        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: None,
-            source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!("raytracing.wgsl"))),
-        });
-
-        let swapchain_capabilities = surface.get_capabilities(&adapter);
-        let swapchain_format = swapchain_capabilities.formats[0];
-        self.pipeline = Some(
-            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-                label: None,
-                layout: Some(&pipeline_layout),
-                vertex: wgpu::VertexState {
-                    module: &shader,
-                    entry_point: "vs_main",
-                    buffers: &[],
-                    compilation_options: Default::default(),
-                },
-                fragment: Some(wgpu::FragmentState {
-                    module: &shader,
-                    entry_point: "fs_main",
-                    compilation_options: Default::default(),
-                    targets: &[Some(swapchain_format.into())],
-                }),
-                primitive: wgpu::PrimitiveState::default(),
-                depth_stencil: None,
-                multisample: wgpu::MultisampleState::default(),
-                multiview: None,
-            }),
-        );
-
-        let config = surface
-            .get_default_config(&adapter, self.output_width, self.output_height)
-            .unwrap();
-        surface.configure(&device, &config);
-
-        self.adapter = Some(adapter);
-        self.surface = Some(surface);
-        self.queue = Some(queue);
-        self.device = Some(device);
-    }
-
     pub fn new(output_width: u32, output_height: u32) -> Self {
-        let wgpu_instance = wgpu::Instance::default();
-        // for adapter in wgpu_instance.enumerate_adapters(wgpu::Backends::all()) {
-        //     println!("{:?}", adapter.get_info())
-        // }
+        let mut result = Self::default();
+        result.output_width = output_width;
+        result.output_height = output_height;
+        result.wgpu_instance = wgpu::Instance::default();
+        result.texture_extent = wgpu::Extent3d {
+            width: output_width,
+            height: output_height,
+            depth_or_array_layers: 1,
+        };
 
-        Self {
-            wgpu_instance,
-            output_width,
-            output_height,
-            window: None,
-            adapter: None,
-            surface: None,
-            device: None,
-            pipeline: None,
-            queue: None,
+        result
+    }
+
+    pub fn update_viewport(&mut self, viewport: Viewport) {
+        if viewport == self.viewport && self.viewport_buffer.is_some() {
+            return;
         }
-    }
-}
 
-impl ApplicationHandler for SvxRenderApp {
-    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
-        self.window = Some(Arc::new(
-            event_loop
-                .create_window(
-                    Window::default_attributes()
-                        .with_title("Voxel Raytracing Render")
-                        .with_inner_size(winit::dpi::PhysicalSize::new(
-                            self.output_width,
-                            self.output_height,
-                        )),
-                )
-                .unwrap(),
-        ));
-        futures::executor::block_on(self.rebuild_pipeline())
+        self.viewport = viewport;
+        self.viewport_buffer = Some(
+            self.device
+                .as_ref()
+                .expect("Expected SvxRenderApp to have a vaild device!")
+                .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                    label: Some("Octree Metadata Buffer"),
+                    contents: bytemuck::cast_slice(&[viewport]),
+                    usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                }),
+        );
     }
 
-    fn window_event(&mut self, event_loop: &ActiveEventLoop, _id: WindowId, event: WindowEvent) {
-        match event {
-            WindowEvent::CloseRequested => {
-                event_loop.exit();
-            }
-            WindowEvent::RedrawRequested => {
-                if self.window.is_none() {
-                    return;
-                }
-                let mut size = self.window.as_ref().unwrap().inner_size();
-                size.width = size.width.max(1);
-                size.height = size.height.max(1);
-
-                let frame = self
-                    .surface
-                    .as_ref()
-                    .expect("Render Surface not available")
-                    .get_current_texture()
-                    .expect("Failed to acquire next swap chain texture");
-
-                let view = frame
-                    .texture
-                    .create_view(&wgpu::TextureViewDescriptor::default());
-                let mut encoder = self
-                    .device
-                    .as_ref()
-                    .expect("Device Encoder not found")
-                    .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
-                {
-                    let mut rpass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
-                        label: None,
-                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
-                            view: &view,
-                            resolve_target: None, //render target!
-                            ops: wgpu::Operations {
-                                load: wgpu::LoadOp::Clear(wgpu::Color::GREEN),
-                                store: wgpu::StoreOp::Store,
-                            },
-                        })],
-                        depth_stencil_attachment: None,
-                        timestamp_writes: None,
-                        occlusion_query_set: None,
-                    });
-                    rpass.set_pipeline(&self.pipeline.as_ref().unwrap());
-                    rpass.draw(0..6, 0..1);
-                }
-
-                self.queue
-                    .as_ref()
-                    .expect("Render Queue not available")
-                    .submit(Some(encoder.finish()));
-                frame.present();
-
-                self.window.as_ref().unwrap().request_redraw();
-            }
-            WindowEvent::Resized(size) => {
-                self.output_width = size.width;
-                self.output_height = size.height;
-                futures::executor::block_on(self.rebuild_pipeline())
-            }
-            _ => (),
-        }
-    }
+    // pub fn update_data(&mut self, tree: Arc<Octree<T, DIM>>) {}
 }

--- a/src/octree/raytracing/wgpu/mod.rs
+++ b/src/octree/raytracing/wgpu/mod.rs
@@ -5,6 +5,7 @@ mod types;
 
 pub use crate::octree::raytracing::wgpu::types::{SvxRenderApp, Viewport};
 use crate::octree::Octree;
+use encase::UniformBuffer;
 use std::sync::Arc;
 
 use wgpu::util::DeviceExt;
@@ -29,6 +30,8 @@ impl SvxRenderApp {
             return;
         }
 
+        let mut buffer = UniformBuffer::new(Vec::<u8>::new());
+        buffer.write(&viewport).unwrap();
         self.viewport = viewport;
         self.viewport_buffer = Some(
             self.device
@@ -36,7 +39,7 @@ impl SvxRenderApp {
                 .expect("Expected SvxRenderApp to have a vaild device!")
                 .create_buffer_init(&wgpu::util::BufferInitDescriptor {
                     label: Some("Octree Metadata Buffer"),
-                    contents: bytemuck::cast_slice(&[viewport]),
+                    contents: &buffer.into_inner(),
                     usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
                 }),
         );

--- a/src/octree/raytracing/wgpu/pipeline.rs
+++ b/src/octree/raytracing/wgpu/pipeline.rs
@@ -1,4 +1,6 @@
 use crate::octree::raytracing::wgpu::SvxRenderApp;
+use crate::octree::raytracing::wgpu::Viewport;
+use encase::UniformBuffer;
 use std::borrow::Cow;
 use wgpu::{util::DeviceExt, TextureUsages};
 
@@ -115,9 +117,11 @@ impl SvxRenderApp {
         });
 
         // re-create viewport
+        let mut buffer = UniformBuffer::new(Vec::<u8>::new());
+        buffer.write(&self.viewport).unwrap();
         let viewport_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
             label: Some("Octree Metadata Buffer"),
-            contents: bytemuck::cast_slice(&[self.viewport]),
+            contents: &buffer.into_inner(),
             usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
         });
 
@@ -156,7 +160,7 @@ impl SvxRenderApp {
                 // viewport
                 wgpu::BindGroupLayoutEntry {
                     binding: 3,
-                    visibility: wgpu::ShaderStages::COMPUTE,
+                    visibility: wgpu::ShaderStages::COMPUTE | wgpu::ShaderStages::FRAGMENT,
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Uniform,
                         has_dynamic_offset: false,

--- a/src/octree/raytracing/wgpu/pipeline.rs
+++ b/src/octree/raytracing/wgpu/pipeline.rs
@@ -1,0 +1,244 @@
+use crate::octree::raytracing::wgpu::SvxRenderApp;
+use std::borrow::Cow;
+use wgpu::{util::DeviceExt, TextureUsages};
+
+impl SvxRenderApp {
+    pub(crate) async fn rebuild_pipeline(&mut self) {
+        assert!(self.window.is_some());
+        let surface = self
+            .wgpu_instance
+            .create_surface(self.window.as_ref().unwrap().clone())
+            .unwrap();
+
+        let adapter = self
+            .wgpu_instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::default(),
+                force_fallback_adapter: false,
+                // Request an adapter which can render to our surface
+                compatible_surface: Some(&surface),
+            })
+            .await
+            .expect("Failed to find an appropriate adapter");
+
+        let (device, queue) = adapter
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    label: None,
+                    required_features: wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES,
+                    // Make sure we use the texture resolution limits from the adapter, so we can support images the size of the swapchain.
+                    required_limits: wgpu::Limits::downlevel_defaults()
+                        .using_resolution(adapter.limits()),
+                },
+                None,
+            )
+            .await
+            .expect("Failed to create device");
+
+        // Create output texture and fill it with a single color
+        let output_texture = device.create_texture(&wgpu::TextureDescriptor {
+            size: self.texture_extent,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: TextureUsages::STORAGE_BINDING
+                | TextureUsages::COPY_SRC
+                | TextureUsages::COPY_DST,
+            label: Some("output_texture"),
+            view_formats: &[],
+        });
+        let output_texture_render = device.create_texture(&wgpu::TextureDescriptor {
+            size: self.texture_extent,
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: TextureUsages::TEXTURE_BINDING | TextureUsages::COPY_DST,
+            label: Some("output_texture"),
+            view_formats: &[],
+        });
+        let mut default_image = image::DynamicImage::ImageRgba8(image::RgbaImage::new(
+            self.output_width,
+            self.output_height,
+        ));
+
+        for x in 0..self.output_width {
+            for y in 0..self.output_height {
+                use image::GenericImage;
+                if 0 == x % 50 || 0 == y % 50 {
+                    default_image.put_pixel(x, y, image::Rgba([200, 255, 200, 255]));
+                } else {
+                    default_image.put_pixel(
+                        x,
+                        y,
+                        image::Rgba([
+                            (255 * x / self.output_width) as u8,
+                            255,
+                            (255 * y / self.output_width) as u8,
+                            255,
+                        ]),
+                    );
+                }
+            }
+        }
+
+        queue.write_texture(
+            wgpu::ImageCopyTexture {
+                texture: &output_texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            &default_image.to_rgba8(),
+            wgpu::ImageDataLayout {
+                offset: 0,
+                bytes_per_row: Some(4 * self.output_width),
+                rows_per_image: Some(self.output_height),
+            },
+            self.texture_extent,
+        );
+
+        // create texture view and sampler
+        let output_texture_view =
+            output_texture.create_view(&wgpu::TextureViewDescriptor::default());
+        let output_texture_render_view =
+            output_texture_render.create_view(&wgpu::TextureViewDescriptor::default());
+        let output_texture_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Linear,
+            min_filter: wgpu::FilterMode::Nearest,
+            mipmap_filter: wgpu::FilterMode::Nearest,
+            ..Default::default()
+        });
+
+        // re-create viewport
+        let viewport_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Octree Metadata Buffer"),
+            contents: bytemuck::cast_slice(&[self.viewport]),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+
+        // Create bind group layout
+        let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            entries: &[
+                // output_texture
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::COMPUTE | wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::StorageTexture {
+                        access: wgpu::StorageTextureAccess::ReadWrite,
+                        format: wgpu::TextureFormat::Rgba8Unorm,
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                    },
+                    count: None,
+                },
+                // output_texture_render
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::COMPUTE | wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Texture {
+                        multisampled: false,
+                        view_dimension: wgpu::TextureViewDimension::D2,
+                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                    },
+                    count: None,
+                },
+                // output_texture sampler
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::FRAGMENT,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    count: None,
+                },
+                // viewport
+                wgpu::BindGroupLayoutEntry {
+                    binding: 3,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
+            label: Some("Dynamic_layout"),
+        });
+
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            layout: &layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(&output_texture_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::TextureView(&output_texture_render_view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: wgpu::BindingResource::Sampler(&output_texture_sampler),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: viewport_buffer.as_entire_binding(),
+                },
+            ],
+            label: Some("Dynamic_bind_group"),
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: None,
+            bind_group_layouts: &[&layout],
+            push_constant_ranges: &[],
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: None,
+            source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!("raytracing.wgsl"))),
+        });
+
+        let swapchain_capabilities = surface.get_capabilities(&adapter);
+        let swapchain_format = swapchain_capabilities.formats[0];
+        self.pipeline = Some(
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: None,
+                layout: Some(&pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: "vs_main",
+                    buffers: &[],
+                    compilation_options: Default::default(),
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: "fs_main",
+                    compilation_options: Default::default(),
+                    targets: &[Some(swapchain_format.into())],
+                }),
+                primitive: wgpu::PrimitiveState::default(),
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview: None,
+            }),
+        );
+
+        let config = surface
+            .get_default_config(&adapter, self.output_width, self.output_height)
+            .unwrap();
+        surface.configure(&device, &config);
+
+        // Set object state
+        self.adapter = Some(adapter);
+        self.surface = Some(surface);
+        self.queue = Some(queue);
+        self.device = Some(device);
+        self.dynamic_group = Some(bind_group);
+        self.output_texture = Some(output_texture);
+        self.output_texture_render = Some(output_texture_render);
+    }
+}

--- a/src/octree/raytracing/wgpu/raytracing.wgsl
+++ b/src/octree/raytracing/wgpu/raytracing.wgsl
@@ -624,22 +624,28 @@ struct Viewport {
     fov: f32,
 }
 
-@group(0) @binding(1)
+@group(0) @binding(0)
 var output_texture: texture_storage_2d<rgba8unorm, read_write>;
 
+@group(0) @binding(1)
+var output_texture_render: texture_2d<f32>;
+
 @group(0) @binding(2)
-var<uniform> viewport: Viewport;
+var output_texture_sampler: sampler;
 
 @group(0) @binding(3)
+var<uniform> viewport: Viewport;
+
+@group(1) @binding(0)
 var<uniform> octreeMetaData: OctreeMetaData;
 
-@group(0) @binding(4)
+@group(1) @binding(1)
 var<storage, read_write> nodes: array<SizedNode>;
 
-@group(0) @binding(5)
+@group(1) @binding(2)
 var<storage, read_write> children_buffer: array<u32>;
 
-@group(0) @binding(6)
+@group(1) @binding(3)
 var<storage, read_write> voxels: array<Voxelement>;
 
 @compute @workgroup_size(8, 8, 1)
@@ -710,6 +716,15 @@ fn vs_main(@builtin(vertex_index) in_vertex_index: u32) -> VertexOutput {
 
 @fragment
 fn fs_main(vertex_output: VertexOutput) -> @location(0) vec4<f32> {
+    let condition = vertex_output.uv < vec2f(0.5,0.5);
+    if condition.x && condition.y {
+        //return textureLoad(output_texture, vec2u(vertex_output.uv * 100));
+        return textureSample(
+            output_texture_render, output_texture_sampler,
+            vertex_output.uv
+        );
+    }
+
     return vec4f(vertex_output.uv, 0.0, 1.0);
 }
 

--- a/src/octree/raytracing/wgpu/raytracing.wgsl
+++ b/src/octree/raytracing/wgpu/raytracing.wgsl
@@ -1,0 +1,813 @@
+struct Line {
+    origin: vec3f,
+    direction: vec3f,
+}
+
+struct Plane {
+    point: vec3f,
+    normal: vec3f,
+}
+
+struct Cube {
+    min_position: vec3f,
+    size: f32,
+}
+
+const FLOAT_ERROR_TOLERANCE = 0.00001;
+const OOB_OCTANT = 8u;
+
+//crate::spatial::raytracing::Cube::contains_point
+fn cube_contains_point(cube: Cube, p: vec3f) -> bool{
+    let min_cn = p >= cube.min_position - FLOAT_ERROR_TOLERANCE;
+    let max_cn = p < (cube.min_position + cube.size + FLOAT_ERROR_TOLERANCE);
+    return (
+        min_cn.x && min_cn.y && min_cn.z && max_cn.x && max_cn.y && max_cn.z
+    );
+}
+
+//Rust::unwrap_or
+fn impact_or(impact: CubeRayIntersection, or: f32) -> f32{
+    if(impact.hit && impact.impact_hit){
+        return impact.impact_distance;
+    }
+    return or;
+}
+
+//crate::spatial::math::hash_region
+fn hash_region(offset: vec3f, size: f32) -> u32 {
+    let midpoint = vec3f(size / 2., size / 2., size / 2.);
+    return u32(offset.x >= midpoint.x)
+        + u32(offset.z >= midpoint.z) * 2u
+        + u32(offset.y >= midpoint.y) * 4u;
+}
+
+//crate::spatial::math::offset_region
+fn offset_region(octant: u32) -> vec3f {
+    switch(octant){
+        case 0u { return vec3f(0., 0., 0.); }
+        case 1u { return vec3f(1., 0., 0.); }
+        case 2u { return vec3f(0., 0., 1.); }
+        case 3u { return vec3f(1., 0., 1.); }
+        case 4u { return vec3f(0., 1., 0.); }
+        case 5u { return vec3f(1., 1., 0.); }
+        case 6u { return vec3f(0., 1., 1.); }
+        case 7u, default { return vec3f(1.,1.,1.); }
+    }
+}
+
+//crate::spatial::mod::Cube::child_bounds_for
+fn child_bounds_for(bounds: Cube, octant: u32) -> Cube{
+    var result: Cube;
+    let child_size = bounds.size / 2.;
+    result.min_position = bounds.min_position + (offset_region(octant) * child_size);
+    result.size = child_size;
+    return result;
+}
+
+struct PlaneLineIntersection {
+    hit: bool,
+    d: f32,
+}
+
+//crate::spatial::math::plane_line_intersection
+fn plane_line_intersection(plane: Plane, line: Line) -> PlaneLineIntersection {
+    var result: PlaneLineIntersection;
+    let origins_diff = plane.point - line.origin;
+    let plane_line_dot_to_plane = dot(origins_diff, plane.normal);
+    let directions_dot = dot(line.direction, plane.normal);
+
+    if 0. == directions_dot {
+        // line and plane is paralell
+        if 0. == dot(origins_diff, plane.normal) {
+            // The distance is zero because the origin is already on the plane
+            result.hit = true;
+            result.d = 0.;
+        } else {
+            result.hit = false;
+        }
+    } else {
+        result.hit = true;
+        result.d = plane_line_dot_to_plane / directions_dot;
+    }
+    return result;
+}
+
+//crate::spatial::raytracing::Cube::face
+fn get_cube_face(cube: Cube, face_index: u32) -> Plane{
+    var result: Plane;
+    switch(face_index){
+        case 0u { result.normal = vec3f(0.,0.,-1.); }
+        case 1u { result.normal = vec3f(-1.,0.,0.); }
+        case 2u { result.normal = vec3f(0.,0.,1.); }
+        case 3u { result.normal = vec3f(1.,0.,0.); }
+        case 4u { result.normal = vec3f(0.,1.,0.); }
+        case 5u, default { result.normal = vec3f(0.,-1.,0.); }
+    }
+    let half_size = cube.size / 2.;
+    let midpoint = cube.min_position + half_size;
+    result.point = midpoint + result.normal * half_size;
+    return result;
+}
+
+struct CubeRayIntersection {
+    hit: bool,
+    impact_hit: bool,
+    impact_distance: f32,
+    exit_distance: f32,
+}
+
+//crate::spatial::raytracing::Ray::point_at
+fn point_in_ray_at_distance(ray: Line, d: f32) -> vec3f{
+    return ray.origin + ray.direction * d;
+}
+
+//crate::spatial::raytracing::Cube::intersect_ray
+fn cube_intersect_ray(cube: Cube, ray: Line) -> CubeRayIntersection{
+    var result: CubeRayIntersection;
+    let max_position = cube.min_position + vec3f(cube.size, cube.size, cube.size);
+    let t1 = (cube.min_position.x - ray.origin.x) / ray.direction.x;
+    let t2 = (max_position.x - ray.origin.x) / ray.direction.x;
+    let t3 = (cube.min_position.y - ray.origin.y) / ray.direction.y;
+    let t4 = (max_position.y - ray.origin.y) / ray.direction.y;
+    let t5 = (cube.min_position.z - ray.origin.z) / ray.direction.z;
+    let t6 = (max_position.z - ray.origin.z) / ray.direction.z;
+
+    let tmin = max(max(min(t1, t2), min(t3, t4)), min(t5, t6));
+    let tmax = min(min(max(t1, t2), max(t3, t4)), max(t5, t6));
+
+    if tmax < 0. || tmin > tmax{
+        result.hit = false;
+        return result;
+    }
+
+    let p = point_in_ray_at_distance(ray, tmin);
+
+
+    if tmin < 0.0 {
+        result.hit = true;
+        result.impact_hit = false;
+        result.exit_distance = tmax;
+        return result;
+    }
+
+    result.hit = true;
+    result.impact_hit = true;
+    result.impact_distance = tmin;
+    result.exit_distance = tmax;
+    return result;
+}
+
+fn cube_impact_normal(cube: Cube, impact_point: vec3f) -> vec3f{
+    var impact_normal = vec3f(0.,0.,0.);
+    let mid_to_impact = cube.min_position + vec3f(cube.size / 2.) - impact_point;
+    let mid_to_impact_abs = abs(mid_to_impact);
+    let max_component = max(
+        mid_to_impact_abs.x,
+        max(mid_to_impact_abs.y, mid_to_impact_abs.z)
+    );
+    if max_component - mid_to_impact_abs.x < FLOAT_ERROR_TOLERANCE {
+        impact_normal.x = -mid_to_impact.x;
+    }
+    if max_component - mid_to_impact_abs.y < FLOAT_ERROR_TOLERANCE {
+        impact_normal.y = -mid_to_impact.y;
+    }
+    if max_component - mid_to_impact_abs.z < FLOAT_ERROR_TOLERANCE {
+        impact_normal.z = -mid_to_impact.z;
+    }
+    return normalize(impact_normal);
+}
+
+struct NodeStackItem {
+    bounds: Cube,
+    node: u32,
+    sized_node_meta: u32,
+    target_octant: u32,
+}
+
+//crate::octree:raytracing::NodeStackItem::new
+fn new_node_stack_item(
+    bounds: Cube,
+    node: u32,
+    sized_node_meta: u32,
+    target_octant: u32
+) -> NodeStackItem {
+    var result: NodeStackItem;
+    result.bounds = bounds;
+    result.node = node;
+    result.target_octant = target_octant;
+    result.sized_node_meta = sized_node_meta;
+    return result;
+}
+
+//crate::octree:raytracing::get_dda_scale_factors
+fn get_dda_scale_factors(ray: Line) -> vec3f {
+    return vec3f(
+        sqrt(
+            1.
+            + pow(ray.direction.z / ray.direction.x, 2.)
+            + pow(ray.direction.y / ray.direction.x, 2.)
+        ),
+        sqrt(
+            pow(ray.direction.x / ray.direction.y, 2.)
+            + 1.
+            + pow(ray.direction.z / ray.direction.y, 2.)
+        ),
+        sqrt(
+            pow(ray.direction.x / ray.direction.z, 2.)
+            + pow(ray.direction.y / ray.direction.z, 2.)
+            + 1.
+        ),
+    );
+}
+
+//crate::octree::raytracing::dda_step_to_next_sibling
+fn dda_step_to_next_sibling(
+    ray: Line, 
+    ray_current_distance: ptr<function,f32>,
+    current_bounds: Cube,
+    ray_scale_factors: vec3f
+) -> vec3f {
+    var signum_vec = sign(ray.direction);
+    let p = point_in_ray_at_distance(ray, *ray_current_distance);
+    let steps_needed = (
+        p - current_bounds.min_position
+        - (current_bounds.size * max(sign(ray.direction), vec3f(0.,0.,0.)))
+    );
+
+    let d = (
+        vec3f(*ray_current_distance, *ray_current_distance, *ray_current_distance) 
+        + abs(steps_needed * ray_scale_factors)
+    );
+    *ray_current_distance = min(d.x, min(d.y, d.z));
+
+    var result = vec3f(0., 0., 0.);
+    if abs(*ray_current_distance - d.x) < FLOAT_ERROR_TOLERANCE {
+        result.x = f32(abs(current_bounds.size)) * signum_vec.x;
+    }
+    if abs(*ray_current_distance - d.y) < FLOAT_ERROR_TOLERANCE {
+        result.y = f32(abs(current_bounds.size)) * signum_vec.y;
+    }
+    if abs(*ray_current_distance - d.z) < FLOAT_ERROR_TOLERANCE {
+        result.z = f32(abs(current_bounds.size)) * signum_vec.z;
+    }
+    return result;
+}
+
+// Unique to this implementation, not adapted from rust code, corresponds to:
+//crate::octree::raytracing::classic_raytracing_on_bevy_wgpu::meta_set_is_leaf
+fn is_leaf(sized_node_meta: u32) -> bool {
+    return 0 < (0x01000000 & sized_node_meta);
+}
+
+// Unique to this implementation, not adapted from rust code, corresponds to:
+//crate::octree::raytracing::classic_raytracing_on_bevy_wgpu::meta_set_node_occupancy_bitmap
+fn get_node_occupancy_bitmap(sized_node_meta: u32) -> u32 {
+    return (0x000000FF & sized_node_meta);
+}
+
+//crate::spatial::math::step_octant
+fn step_octant(octant: u32, step: vec3f) -> u32 {
+    let octant_pos_in_32bits = 4 * octant;
+    return ((OCTANT_STEP_RESULT_LUT[u32(sign(step.x) + 1)][u32(sign(step.y) + 1)][u32(sign(step.z) + 1)]
+        & (0x0Fu << octant_pos_in_32bits))
+        >> octant_pos_in_32bits) & 0x0Fu;
+}
+
+//crate::spatial::math::hash_direction
+fn hash_direction(direction: vec3f) -> u32 {
+    let offset = vec3f(1.) + normalize(direction);
+    return hash_region(offset, 2.);
+}
+
+// Functionality-wise this function is more generic, than its counterpart
+// and is used in voxel brick mapping too
+//crate::spatial::math::flat_projection
+fn flat_projection(i: vec3u, dimensions: vec2u) -> u32 {
+    return (i.x + (i.y * dimensions.y) + (i.z * dimensions.x * dimensions.y));
+}
+
+//crate::spatial::math::position_in_bitmap_64bits
+fn position_in_bitmap_64bits(i: vec3u, dimension: u32) -> u32{
+    let pos_inside_bitmap_space = i * 4 / dimension;
+    //let pos_inside_bitmap_space = vec3u((vec3f(i) * 4.) / f32(dimension));
+    let pos_inside_bitmap = flat_projection(
+        pos_inside_bitmap_space, vec2u(4, 4)
+    );
+    return pos_inside_bitmap;
+}
+
+// Unique to this implementation, not adapted from rust code
+fn get_occupancy_in_bitmap_64bits(
+    bit_position: u32,
+    bitmap_lsb: u32,
+    bitmap_msb: u32
+) -> bool {
+    // not possible to create a position mask directly, because of missing u64 type
+    if bit_position < 32 {
+        let pos_mask = u32(0x01u << bit_position);
+        return 0 < (bitmap_lsb & pos_mask);
+    }
+    let pos_mask = u32(0x01u << (bit_position - 32));
+    return 0 < (bitmap_msb & pos_mask);
+}
+
+struct BrickHit{
+    hit: bool,
+    index: vec3u
+}
+
+fn traverse_brick(
+    ray: Line,
+    ray_current_distance: ptr<function,f32>,
+    brick_index_start: u32,
+    occupancy_bitmap_lsb: u32,
+    occupancy_bitmap_msb: u32,
+    bounds: Cube,
+    ray_scale_factors: vec3f,
+    direction_lut_index: u32,
+    unit_in_bitmap_space: f32, 
+    dimension: u32
+) -> BrickHit{
+    var result: BrickHit;
+    result.hit = false;
+
+    let pos = (
+        point_in_ray_at_distance(ray, *ray_current_distance)
+        - bounds.min_position
+    );
+    var current_index = vec3i(
+        clamp(i32(pos.x), 0, i32(dimension - 1)),
+        clamp(i32(pos.y), 0, i32(dimension - 1)),
+        clamp(i32(pos.z), 0, i32(dimension - 1))
+    );
+    let brick_unit = bounds.size / f32(dimension);
+    var current_bounds = Cube(
+        bounds.min_position + vec3f(current_index) * brick_unit,
+        brick_unit
+    );
+
+    let start_pos_in_bitmap = position_in_bitmap_64bits(vec3u(current_index), dimension);
+    if (
+        0 == (RAY_TO_LEAF_OCCUPANCY_BITMASK_LUT[start_pos_in_bitmap][direction_lut_index * 2]
+            & occupancy_bitmap_lsb)
+        && 0 == (RAY_TO_LEAF_OCCUPANCY_BITMASK_LUT[start_pos_in_bitmap][direction_lut_index * 2 + 1]
+            & occupancy_bitmap_msb)
+    ){
+        result.hit = false;
+        return result;
+    }
+
+    var prev_bitmap_position_full_resolution = vec3u(vec3f(current_index) * unit_in_bitmap_space);
+    loop{
+        if current_index.x < 0
+            || current_index.x >= i32(dimension)
+            || current_index.y < 0
+            || current_index.y >= i32(dimension)
+            || current_index.z < 0
+            || current_index.z >= i32(dimension)
+        {
+            result.hit = false;
+            return result;
+        }
+
+        let bitmap_position_full_resolution = vec3u(vec3f(current_index) * unit_in_bitmap_space);
+        let differs = bitmap_position_full_resolution != prev_bitmap_position_full_resolution;
+        if(differs.x || differs.y || differs.z) {
+            prev_bitmap_position_full_resolution = bitmap_position_full_resolution;
+            let start_pos_in_bitmap = flat_projection(
+                vec3u(bitmap_position_full_resolution), vec2u(4, 4),
+            );
+            if (
+                0 == (RAY_TO_LEAF_OCCUPANCY_BITMASK_LUT[start_pos_in_bitmap][direction_lut_index * 2]
+                    & occupancy_bitmap_lsb)
+                && 0 == (RAY_TO_LEAF_OCCUPANCY_BITMASK_LUT[start_pos_in_bitmap][direction_lut_index * 2 + 1]
+                    & occupancy_bitmap_msb)
+            ){
+                result.hit = false;
+                return result;
+            }
+        }
+
+        let voxel_brick_index = u32(flat_projection(
+            vec3u(current_index),
+            vec2u(dimension, dimension)
+        ));
+        if !is_empty(voxels[brick_index_start + voxel_brick_index])
+        {
+            result.hit = true;
+            result.index = vec3u(current_index);
+            return result;
+        }
+
+        let step = dda_step_to_next_sibling(
+            ray,
+            ray_current_distance,
+            current_bounds,
+            ray_scale_factors
+        );
+        current_bounds.min_position = current_bounds.min_position + vec3f(step);
+        current_index = current_index + vec3i(step);
+    }
+    return result;
+}
+
+struct OctreeRayIntersection {
+    hit: bool,
+    albedo : vec4<f32>,
+    content: u32,
+    collision_point: vec3f,
+    impact_normal: vec3f,
+}
+
+const max_depth = 20; // the depth for an octree the size of 1048576
+                      // which would be approximately 10 km in case 1 voxel is 1 cm
+fn get_by_ray(ray_: Line) -> OctreeRayIntersection{
+    var result: OctreeRayIntersection;
+    let dimension = octreeMetaData.voxel_brick_dim;
+    let voxelement_count = arrayLength(&voxels);
+    let node_count = arrayLength(&nodes);
+
+    // Eliminate all zeroes within the direction of the ray
+    var ray = ray_;
+    if 0. == ray.direction.x {
+        ray.direction.x = FLOAT_ERROR_TOLERANCE;
+    }
+    if 0. == ray.direction.y {
+        ray.direction.y = FLOAT_ERROR_TOLERANCE;
+    }
+    if 0. == ray.direction.z {
+        ray.direction.z = FLOAT_ERROR_TOLERANCE;
+    }
+
+    let ray_scale_factors = get_dda_scale_factors(ray);
+    let direction_lut_index = hash_direction(ray.direction);
+
+    var root_bounds = Cube(vec3(0.,0.,0.), f32(octreeMetaData.octree_size));
+    var ray_current_distance: f32  = 0.0;
+    var node_stack: array<NodeStackItem, max_depth>;
+    var node_stack_i: i32 = 0;
+    let unit_in_bitmap_space = 4. / f32(dimension);
+
+    let root_intersection = cube_intersect_ray(root_bounds, ray);
+    if(root_intersection.hit){
+        ray_current_distance = impact_or(root_intersection, 0.);
+        let target_octant = hash_region(
+            point_in_ray_at_distance(ray, ray_current_distance) - root_bounds.min_position,
+            root_bounds.size,
+        );
+        node_stack[0] = new_node_stack_item(
+            root_bounds,
+            OCTREE_ROOT_NODE_KEY,
+            nodes[OCTREE_ROOT_NODE_KEY].sized_node_meta,
+            target_octant
+        );
+        node_stack_i = 1;
+    }
+    while(0 < node_stack_i && node_stack_i < max_depth) {
+        var current_bounds = node_stack[node_stack_i - 1].bounds;
+        var current_node = nodes[node_stack[node_stack_i - 1].node]; //!NOTE: should be const, but then it can not be indexed dynamically
+        var target_octant = node_stack[node_stack_i - 1].target_octant;
+
+        var leaf_miss = false;
+        if is_leaf(current_node.sized_node_meta) {
+            let leaf_brick_hit = traverse_brick(
+                ray, &ray_current_distance, current_node.voxels_start_at,
+                children_buffer[current_node.children_starts_at],
+                children_buffer[current_node.children_starts_at + 1],
+                current_bounds, ray_scale_factors, direction_lut_index,
+                unit_in_bitmap_space, dimension
+            );
+            if leaf_brick_hit.hit == true {
+                let hit_in_voxels = (
+                    current_node.voxels_start_at
+                    + u32(flat_projection( leaf_brick_hit.index, vec2u(dimension, dimension )))
+                );
+                current_bounds.size /= f32(dimension);
+                current_bounds.min_position = current_bounds.min_position
+                    + vec3f(leaf_brick_hit.index) * current_bounds.size;
+                result.hit = true;
+                result.albedo = voxels[hit_in_voxels].albedo;
+                result.content = voxels[hit_in_voxels].content;
+                result.collision_point = point_in_ray_at_distance(ray, ray_current_distance);
+                result.impact_normal = cube_impact_normal(current_bounds, result.collision_point);
+                return result;
+            }
+            leaf_miss = true;
+        }
+        if( leaf_miss
+            || target_octant == OOB_OCTANT
+            || ( 0 == (
+                get_node_occupancy_bitmap(current_node.sized_node_meta)
+                | RAY_TO_NODE_OCCUPANCY_BITMASK_LUT[target_octant][direction_lut_index]
+            ))
+            || 0 == get_node_occupancy_bitmap(current_node.sized_node_meta)
+        ){
+            // POP
+            let popped_target = node_stack[node_stack_i - 1];
+            node_stack_i -= 1;
+            if(0 < node_stack_i){
+                let step_vec = dda_step_to_next_sibling(
+                    ray,
+                    &ray_current_distance,
+                    popped_target.bounds,
+                    ray_scale_factors
+                );
+                node_stack[node_stack_i - 1].target_octant = step_octant(
+                    node_stack[node_stack_i - 1].target_octant,
+                    step_vec
+                );
+            }
+            continue;
+        }
+
+        var target_bounds = child_bounds_for(current_bounds, target_octant);
+        var target_child_key = children_buffer[current_node.children_starts_at + target_octant];
+        let target_is_empty = (
+            target_child_key >= node_count //!crate::object_pool::key_is_valid
+            || 0 == (
+                get_node_occupancy_bitmap( current_node.sized_node_meta )
+                & ( // crate::spatial::math::octant_bitmask
+                    0x00000001u << (target_octant & 0x000000FF)
+                )
+            )
+        );
+
+        if !target_is_empty {
+            // PUSH
+            let child_target_octant = hash_region(
+                (point_in_ray_at_distance(ray, ray_current_distance) - target_bounds.min_position),
+                target_bounds.size
+            );
+            node_stack[node_stack_i] = new_node_stack_item(
+                target_bounds,
+                target_child_key,
+                nodes[target_child_key].sized_node_meta,
+                child_target_octant
+            );
+            node_stack_i += 1;
+        } else {
+            // ADVANCE
+            loop {
+                let step_vec = dda_step_to_next_sibling(
+                    ray,
+                    &ray_current_distance,
+                    target_bounds,
+                    ray_scale_factors
+                );
+                target_octant = step_octant(target_octant, step_vec);
+                if OOB_OCTANT != target_octant {
+                    target_bounds = child_bounds_for(current_bounds, target_octant);
+                    target_child_key =
+                        children_buffer[current_node.children_starts_at + target_octant];
+                }
+
+                if (
+                    target_octant == OOB_OCTANT
+                    || (
+                        target_child_key < node_count //crate::object_pool::key_is_valid
+                        && 0 != (
+                            get_node_occupancy_bitmap( current_node.sized_node_meta )
+                            & (0x00000001u << (target_octant & 0x000000FF)) // crate::spatial::math::octant_bitmask
+                        )
+                        && 0 != (
+                            get_node_occupancy_bitmap(nodes[target_child_key].sized_node_meta)
+                            & RAY_TO_NODE_OCCUPANCY_BITMASK_LUT[hash_region(
+                                point_in_ray_at_distance(ray, ray_current_distance) - target_bounds.min_position,
+                                target_bounds.size
+                            )][direction_lut_index]
+                        )
+                    )
+                ){
+                    node_stack[node_stack_i - 1].target_octant = target_octant;
+                    break;
+                }
+            }
+        }
+    }
+    result.hit = false;
+    return result;
+}
+
+struct Voxelement {
+    albedo : vec4<f32>,
+    content: u32,
+}
+
+fn is_empty(e: Voxelement) -> bool {
+    return (
+        0. == e.albedo.r
+        && 0. == e.albedo.g
+        && 0. == e.albedo.b
+        && 0. == e.albedo.a
+        && 0 == e.content
+    );
+}
+
+struct SizedNode {
+    sized_node_meta: u32,
+    children_starts_at: u32,
+    voxels_start_at: u32,
+}
+
+const OCTREE_ROOT_NODE_KEY = 0u;
+struct OctreeMetaData {
+    octree_size: u32,
+    voxel_brick_dim: u32,
+    ambient_light_color: vec4f,
+    ambient_light_position: vec3f,
+}
+
+struct Viewport {
+    origin: vec3f,
+    direction: vec3f,
+    size: vec2f,
+    fov: f32,
+}
+
+@group(0) @binding(1)
+var output_texture: texture_storage_2d<rgba8unorm, read_write>;
+
+@group(0) @binding(2)
+var<uniform> viewport: Viewport;
+
+@group(0) @binding(3)
+var<uniform> octreeMetaData: OctreeMetaData;
+
+@group(0) @binding(4)
+var<storage, read_write> nodes: array<SizedNode>;
+
+@group(0) @binding(5)
+var<storage, read_write> children_buffer: array<u32>;
+
+@group(0) @binding(6)
+var<storage, read_write> voxels: array<Voxelement>;
+
+@compute @workgroup_size(8, 8, 1)
+fn update(
+    @builtin(global_invocation_id) invocation_id: vec3<u32>,
+    @builtin(num_workgroups) num_workgroups: vec3<u32>,
+) {
+    let pixel_location = vec2u(invocation_id.xy);
+    let pixel_location_normalized = vec2f(
+        f32(invocation_id.x) / f32(num_workgroups.x * 8),
+        f32(invocation_id.y) / f32(num_workgroups.y * 8)
+    );
+    let viewport_up_direction = vec3f(0., 1., 0.);
+    let viewport_right_direction = normalize(cross(
+        viewport_up_direction, viewport.direction
+    ));
+    let viewport_bottom_left = viewport.origin 
+        + (viewport.direction * viewport.fov)
+        - (viewport_right_direction * (viewport.size.x / 2.))
+        - (viewport_up_direction * (viewport.size.y / 2.))
+        ;
+    let ray_endpoint = viewport_bottom_left
+        + viewport_right_direction * viewport.size.x * f32(pixel_location_normalized.x)
+        + viewport_up_direction * viewport.size.y * (1. - f32(pixel_location_normalized.y))
+        ;
+    var ray = Line(ray_endpoint, normalize(ray_endpoint - viewport.origin));
+
+    var ray_result = get_by_ray(ray);
+    var rgb_result = vec3f(0.5,0.5,0.5);
+    if ray_result.hit == true {
+        let diffuse_light_strength = (
+            dot(ray_result.impact_normal, vec3f(-0.5,0.5,-0.5)) / 2. + 0.5
+        );
+        let result_with_lights = ray_result.albedo.rgb * diffuse_light_strength;
+        rgb_result = result_with_lights.rgb;
+    }
+
+    textureStore(output_texture, pixel_location, vec4f(rgb_result, 1.));
+}
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) in_vertex_index: u32) -> VertexOutput {
+    // map the input vertex index values to rectangle x,y coordinates
+    var x = 0.; var y = 0.;
+    if 0 == in_vertex_index || 3 == in_vertex_index {
+        x = -1.;
+        y = -1.;
+    }else if 1 == in_vertex_index {
+        x = -1.;
+        y = 1.;
+    }else if 2 == in_vertex_index || 4 == in_vertex_index {
+        x = 1.;
+        y = 1.;
+    }else if 5 == in_vertex_index {
+        x = 1.;
+        y = -1.;
+    }
+
+    let pos = vec4f(x, y, 0.0, 1.0);
+    let uv = vec2f((x + 1.) / 2.,(y + 1.) / 2.);
+    return VertexOutput(pos,uv);
+}
+
+@fragment
+fn fs_main(vertex_output: VertexOutput) -> @location(0) vec4<f32> {
+    return vec4f(vertex_output.uv, 0.0, 1.0);
+}
+
+// Note: should be const
+var<private> OCTANT_STEP_RESULT_LUT: array<array<array<u32, 3>, 3>, 3> = array<array<array<u32, 3>, 3>, 3>(
+    array<array<u32, 3>, 3>(
+        array<u32, 3>(143165576,671647880,2284357768),
+        array<u32, 3>(1216874632,1749559304,2288551976),
+        array<u32, 3>(2290632840,2290640968,2290649192)
+    ),
+    array<array<u32, 3>, 3>(
+        array<u32, 3>(277383304,839944328,2285013128),
+        array<u32, 3>(1418203272,1985229328,2289469490),
+        array<u32, 3>(2290635912,2290644564,2290649206)
+    ),
+    array<array<u32, 3>, 3>(
+        array<u32, 3>(2173208712,2206304392,2290321544),
+        array<u32, 3>(2240315784,2273674113,2290583683),
+        array<u32, 3>(2290648456,2290648965,2290649223)
+    )
+);
+
+// Note: should be const
+var<private> RAY_TO_NODE_OCCUPANCY_BITMASK_LUT: array<array<u32, 8>, 8> = array<array<u32, 8>, 8>(
+    array<u32, 8>(1, 3, 5, 15, 17, 51, 85, 255),
+    array<u32, 8>(3, 2, 15, 10, 51, 34, 255, 170),
+    array<u32, 8>(5, 15, 4, 12, 85, 255, 68, 204),
+    array<u32, 8>(15, 10, 12, 8, 255, 170, 204, 136),
+    array<u32, 8>(17, 51, 85, 255, 16, 48, 80, 240),
+    array<u32, 8>(51, 34, 255, 170, 48, 32, 240, 160),
+    array<u32, 8>(85, 255, 68, 204, 80, 240, 64, 192),
+    array<u32, 8>(255, 170, 204, 136, 240, 160, 192, 128),
+);
+
+// Note: should be const
+var<private> RAY_TO_LEAF_OCCUPANCY_BITMASK_LUT: array<array<u32, 16>, 64> = array<array<u32, 16>, 64>(
+    array<u32, 16>(1,0,15,0,65537,65537,983055,983055,4369,0,65535,0,286331153,286331153,4294967295,4294967295,),
+    array<u32, 16>(3,0,14,0,196611,196611,917518,917518,13107,0,61166,0,858993459,858993459,4008636142,4008636142,),
+    array<u32, 16>(7,0,12,0,458759,458759,786444,786444,30583,0,52428,0,2004318071,2004318071,3435973836,3435973836,),
+    array<u32, 16>(15,0,8,0,983055,983055,524296,524296,65535,0,34952,0,4294967295,4294967295,2290649224,2290649224,),
+    array<u32, 16>(17,0,255,0,1114129,1114129,16711935,16711935,4368,0,65520,0,286265616,286265616,4293984240,4293984240,),
+    array<u32, 16>(51,0,238,0,3342387,3342387,15597806,15597806,13104,0,61152,0,858796848,858796848,4007718624,4007718624,),
+    array<u32, 16>(119,0,204,0,7798903,7798903,13369548,13369548,30576,0,52416,0,2003859312,2003859312,3435187392,3435187392,),
+    array<u32, 16>(255,0,136,0,16711935,16711935,8913032,8913032,65520,0,34944,0,4293984240,4293984240,2290124928,2290124928,),
+    array<u32, 16>(273,0,4095,0,17891601,17891601,268374015,268374015,4352,0,65280,0,285217024,285217024,4278255360,4278255360,),
+    array<u32, 16>(819,0,3822,0,53674803,53674803,250482414,250482414,13056,0,60928,0,855651072,855651072,3993038336,3993038336,),
+    array<u32, 16>(1911,0,3276,0,125241207,125241207,214699212,214699212,30464,0,52224,0,1996519168,1996519168,3422604288,3422604288,),
+    array<u32, 16>(4095,0,2184,0,268374015,268374015,143132808,143132808,65280,0,34816,0,4278255360,4278255360,2281736192,2281736192,),
+    array<u32, 16>(4369,0,65535,0,286331153,286331153,4294967295,4294967295,4096,0,61440,0,268439552,268439552,4026593280,4026593280,),
+    array<u32, 16>(13107,0,61166,0,858993459,858993459,4008636142,4008636142,12288,0,57344,0,805318656,805318656,3758153728,3758153728,),
+    array<u32, 16>(30583,0,52428,0,2004318071,2004318071,3435973836,3435973836,28672,0,49152,0,1879076864,1879076864,3221274624,3221274624,),
+    array<u32, 16>(65535,0,34952,0,4294967295,4294967295,2290649224,2290649224,61440,0,32768,0,4026593280,4026593280,2147516416,2147516416,),
+    array<u32, 16>(65537,0,983055,0,65536,65537,983040,983055,286331153,0,4294967295,0,286326784,286331153,4294901760,4294967295,),
+    array<u32, 16>(196611,0,917518,0,196608,196611,917504,917518,858993459,0,4008636142,0,858980352,858993459,4008574976,4008636142,),
+    array<u32, 16>(458759,0,786444,0,458752,458759,786432,786444,2004318071,0,3435973836,0,2004287488,2004318071,3435921408,3435973836,),
+    array<u32, 16>(983055,0,524296,0,983040,983055,524288,524296,4294967295,0,2290649224,0,4294901760,4294967295,2290614272,2290649224,),
+    array<u32, 16>(1114129,0,16711935,0,1114112,1114129,16711680,16711935,286265616,0,4293984240,0,286261248,286265616,4293918720,4293984240,),
+    array<u32, 16>(3342387,0,15597806,0,3342336,3342387,15597568,15597806,858796848,0,4007718624,0,858783744,858796848,4007657472,4007718624,),
+    array<u32, 16>(7798903,0,13369548,0,7798784,7798903,13369344,13369548,2003859312,0,3435187392,0,2003828736,2003859312,3435134976,3435187392,),
+    array<u32, 16>(16711935,0,8913032,0,16711680,16711935,8912896,8913032,4293984240,0,2290124928,0,4293918720,4293984240,2290089984,2290124928,),
+    array<u32, 16>(17891601,0,268374015,0,17891328,17891601,268369920,268374015,285217024,0,4278255360,0,285212672,285217024,4278190080,4278255360,),
+    array<u32, 16>(53674803,0,250482414,0,53673984,53674803,250478592,250482414,855651072,0,3993038336,0,855638016,855651072,3992977408,3993038336,),
+    array<u32, 16>(125241207,0,214699212,0,125239296,125241207,214695936,214699212,1996519168,0,3422604288,0,1996488704,1996519168,3422552064,3422604288,),
+    array<u32, 16>(268374015,0,143132808,0,268369920,268374015,143130624,143132808,4278255360,0,2281736192,0,4278190080,4278255360,2281701376,2281736192,),
+    array<u32, 16>(286331153,0,4294967295,0,286326784,286331153,4294901760,4294967295,268439552,0,4026593280,0,268435456,268439552,4026531840,4026593280,),
+    array<u32, 16>(858993459,0,4008636142,0,858980352,858993459,4008574976,4008636142,805318656,0,3758153728,0,805306368,805318656,3758096384,3758153728,),
+    array<u32, 16>(2004318071,0,3435973836,0,2004287488,2004318071,3435921408,3435973836,1879076864,0,3221274624,0,1879048192,1879076864,3221225472,3221274624,),
+    array<u32, 16>(4294967295,0,2290649224,0,4294901760,4294967295,2290614272,2290649224,4026593280,0,2147516416,0,4026531840,4026593280,2147483648,2147516416,),
+    array<u32, 16>(65537,1,983055,15,0,65537,0,983055,286331153,4369,4294967295,65535,0,286331153,0,4294967295,),
+    array<u32, 16>(196611,3,917518,14,0,196611,0,917518,858993459,13107,4008636142,61166,0,858993459,0,4008636142,),
+    array<u32, 16>(458759,7,786444,12,0,458759,0,786444,2004318071,30583,3435973836,52428,0,2004318071,0,3435973836,),
+    array<u32, 16>(983055,15,524296,8,0,983055,0,524296,4294967295,65535,2290649224,34952,0,4294967295,0,2290649224,),
+    array<u32, 16>(1114129,17,16711935,255,0,1114129,0,16711935,286265616,4368,4293984240,65520,0,286265616,0,4293984240,),
+    array<u32, 16>(3342387,51,15597806,238,0,3342387,0,15597806,858796848,13104,4007718624,61152,0,858796848,0,4007718624,),
+    array<u32, 16>(7798903,119,13369548,204,0,7798903,0,13369548,2003859312,30576,3435187392,52416,0,2003859312,0,3435187392,),
+    array<u32, 16>(16711935,255,8913032,136,0,16711935,0,8913032,4293984240,65520,2290124928,34944,0,4293984240,0,2290124928,),
+    array<u32, 16>(17891601,273,268374015,4095,0,17891601,0,268374015,285217024,4352,4278255360,65280,0,285217024,0,4278255360,),
+    array<u32, 16>(53674803,819,250482414,3822,0,53674803,0,250482414,855651072,13056,3993038336,60928,0,855651072,0,3993038336,),
+    array<u32, 16>(125241207,1911,214699212,3276,0,125241207,0,214699212,1996519168,30464,3422604288,52224,0,1996519168,0,3422604288,),
+    array<u32, 16>(268374015,4095,143132808,2184,0,268374015,0,143132808,4278255360,65280,2281736192,34816,0,4278255360,0,2281736192,),
+    array<u32, 16>(286331153,4369,4294967295,65535,0,286331153,0,4294967295,268439552,4096,4026593280,61440,0,268439552,0,4026593280,),
+    array<u32, 16>(858993459,13107,4008636142,61166,0,858993459,0,4008636142,805318656,12288,3758153728,57344,0,805318656,0,3758153728,),
+    array<u32, 16>(2004318071,30583,3435973836,52428,0,2004318071,0,3435973836,1879076864,28672,3221274624,49152,0,1879076864,0,3221274624,),
+    array<u32, 16>(4294967295,65535,2290649224,34952,0,4294967295,0,2290649224,4026593280,61440,2147516416,32768,0,4026593280,0,2147516416,),
+    array<u32, 16>(65537,65537,983055,983055,0,65536,0,983040,286331153,286331153,4294967295,4294967295,0,286326784,0,4294901760,),
+    array<u32, 16>(196611,196611,917518,917518,0,196608,0,917504,858993459,858993459,4008636142,4008636142,0,858980352,0,4008574976,),
+    array<u32, 16>(458759,458759,786444,786444,0,458752,0,786432,2004318071,2004318071,3435973836,3435973836,0,2004287488,0,3435921408,),
+    array<u32, 16>(983055,983055,524296,524296,0,983040,0,524288,4294967295,4294967295,2290649224,2290649224,0,4294901760,0,2290614272,),
+    array<u32, 16>(1114129,1114129,16711935,16711935,0,1114112,0,16711680,286265616,286265616,4293984240,4293984240,0,286261248,0,4293918720,),
+    array<u32, 16>(3342387,3342387,15597806,15597806,0,3342336,0,15597568,858796848,858796848,4007718624,4007718624,0,858783744,0,4007657472,),
+    array<u32, 16>(7798903,7798903,13369548,13369548,0,7798784,0,13369344,2003859312,2003859312,3435187392,3435187392,0,2003828736,0,3435134976,),
+    array<u32, 16>(16711935,16711935,8913032,8913032,0,16711680,0,8912896,4293984240,4293984240,2290124928,2290124928,0,4293918720,0,2290089984,),
+    array<u32, 16>(17891601,17891601,268374015,268374015,0,17891328,0,268369920,285217024,285217024,4278255360,4278255360,0,285212672,0,4278190080,),
+    array<u32, 16>(53674803,53674803,250482414,250482414,0,53673984,0,250478592,855651072,855651072,3993038336,3993038336,0,855638016,0,3992977408,),
+    array<u32, 16>(125241207,125241207,214699212,214699212,0,125239296,0,214695936,1996519168,1996519168,3422604288,3422604288,0,1996488704,0,3422552064,),
+    array<u32, 16>(268374015,268374015,143132808,143132808,0,268369920,0,143130624,4278255360,4278255360,2281736192,2281736192,0,4278190080,0,2281701376,),
+    array<u32, 16>(286331153,286331153,4294967295,4294967295,0,286326784,0,4294901760,268439552,268439552,4026593280,4026593280,0,268435456,0,4026531840,),
+    array<u32, 16>(858993459,858993459,4008636142,4008636142,0,858980352,0,4008574976,805318656,805318656,3758153728,3758153728,0,805306368,0,3758096384,),
+    array<u32, 16>(2004318071,2004318071,3435973836,3435973836,0,2004287488,0,3435921408,1879076864,1879076864,3221274624,3221274624,0,1879048192,0,3221225472,),
+    array<u32, 16>(4294967295,4294967295,2290649224,2290649224,0,4294901760,0,2290614272,4026593280,4026593280,2147516416,2147516416,0,4026531840,0,2147483648,),
+);

--- a/src/octree/raytracing/wgpu/raytracing.wgsl
+++ b/src/octree/raytracing/wgpu/raytracing.wgsl
@@ -620,8 +620,7 @@ struct OctreeMetaData {
 struct Viewport {
     origin: vec3f,
     direction: vec3f,
-    size: vec2f,
-    fov: f32,
+    w_h_fov: vec3f,
 }
 
 @group(0) @binding(0)
@@ -663,13 +662,13 @@ fn update(
         viewport_up_direction, viewport.direction
     ));
     let viewport_bottom_left = viewport.origin 
-        + (viewport.direction * viewport.fov)
-        - (viewport_right_direction * (viewport.size.x / 2.))
-        - (viewport_up_direction * (viewport.size.y / 2.))
+        + (viewport.direction * viewport.w_h_fov.z)
+        - (viewport_right_direction * (viewport.w_h_fov.x / 2.))
+        - (viewport_up_direction * (viewport.w_h_fov.y / 2.))
         ;
     let ray_endpoint = viewport_bottom_left
-        + viewport_right_direction * viewport.size.x * f32(pixel_location_normalized.x)
-        + viewport_up_direction * viewport.size.y * (1. - f32(pixel_location_normalized.y))
+        + viewport_right_direction * viewport.w_h_fov.x * f32(pixel_location_normalized.x)
+        + viewport_up_direction * viewport.w_h_fov.y * (1. - f32(pixel_location_normalized.y))
         ;
     var ray = Line(ray_endpoint, normalize(ray_endpoint - viewport.origin));
 
@@ -716,7 +715,8 @@ fn vs_main(@builtin(vertex_index) in_vertex_index: u32) -> VertexOutput {
 
 @fragment
 fn fs_main(vertex_output: VertexOutput) -> @location(0) vec4<f32> {
-    let condition = vertex_output.uv < vec2f(0.5,0.5);
+    // Display initial texture
+/*    let condition = vertex_output.uv < vec2f(0.5,0.5);
     if condition.x && condition.y {
         //return textureLoad(output_texture, vec2u(vertex_output.uv * 100));
         return textureSample(
@@ -726,6 +726,11 @@ fn fs_main(vertex_output: VertexOutput) -> @location(0) vec4<f32> {
     }
 
     return vec4f(vertex_output.uv, 0.0, 1.0);
+*/
+
+    // Display viewport
+    //return vec4f(0.,0.2,1., 1.);
+    return vec4f(viewport.origin, 1.);
 }
 
 // Note: should be const

--- a/src/octree/raytracing/wgpu/render.rs
+++ b/src/octree/raytracing/wgpu/render.rs
@@ -1,0 +1,112 @@
+pub use crate::octree::raytracing::wgpu::types::SvxRenderApp;
+
+use std::sync::Arc;
+use winit::{
+    application::ApplicationHandler,
+    event::WindowEvent,
+    event_loop::ActiveEventLoop,
+    window::{Window, WindowId},
+};
+
+impl ApplicationHandler for SvxRenderApp {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        self.window = Some(Arc::new(
+            event_loop
+                .create_window(
+                    Window::default_attributes()
+                        .with_title("Voxel Raytracing Render")
+                        .with_inner_size(winit::dpi::PhysicalSize::new(
+                            self.output_width,
+                            self.output_height,
+                        )),
+                )
+                .unwrap(),
+        ));
+        futures::executor::block_on(self.rebuild_pipeline())
+    }
+
+    fn window_event(&mut self, event_loop: &ActiveEventLoop, _id: WindowId, event: WindowEvent) {
+        match event {
+            WindowEvent::CloseRequested => {
+                event_loop.exit();
+            }
+            WindowEvent::RedrawRequested => {
+                if self.window.is_none() {
+                    return;
+                }
+                let mut size = self.window.as_ref().unwrap().inner_size();
+                size.width = size.width.max(1);
+                size.height = size.height.max(1);
+
+                let frame = self
+                    .surface
+                    .as_ref()
+                    .expect("Render Surface not available")
+                    .get_current_texture()
+                    .expect("Failed to acquire next swap chain texture");
+
+                let view = frame
+                    .texture
+                    .create_view(&wgpu::TextureViewDescriptor::default());
+                let mut encoder = self
+                    .device
+                    .as_ref()
+                    .expect("Device Encoder not found")
+                    .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+
+                encoder.copy_texture_to_texture(
+                    self.output_texture
+                        .as_ref()
+                        .expect("Expected Output texture")
+                        .as_image_copy(),
+                    self.output_texture_render
+                        .as_ref()
+                        .expect("Expected Output render texture")
+                        .as_image_copy(),
+                    self.texture_extent,
+                );
+
+                {
+                    let mut render_pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                        label: None,
+                        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                            view: &view,
+                            resolve_target: None, //render target!
+                            ops: wgpu::Operations {
+                                load: wgpu::LoadOp::Clear(wgpu::Color::GREEN),
+                                store: wgpu::StoreOp::Store,
+                            },
+                        })],
+                        depth_stencil_attachment: None,
+                        timestamp_writes: None,
+                        occlusion_query_set: None,
+                    });
+                    render_pass.set_pipeline(&self.pipeline.as_ref().unwrap());
+                    render_pass.set_bind_group(
+                        0,
+                        &self
+                            .dynamic_group
+                            .as_ref()
+                            .expect("Expected Dynamic Bind Group"),
+                        &[],
+                    );
+                    render_pass.draw(0..6, 0..1);
+                }
+
+                self.queue
+                    .as_ref()
+                    .expect("Render Queue not available")
+                    .submit(Some(encoder.finish()));
+                frame.present();
+
+                self.window.as_ref().unwrap().request_redraw();
+            }
+            WindowEvent::Resized(size) => {
+                self.output_width = size.width;
+                self.output_height = size.height;
+                futures::executor::block_on(self.rebuild_pipeline())
+            }
+            _ => (),
+        }
+    }
+}

--- a/src/octree/raytracing/wgpu/types.rs
+++ b/src/octree/raytracing/wgpu/types.rs
@@ -1,0 +1,106 @@
+use bytemuck::{Pod, Zeroable};
+
+use std::sync::Arc;
+use wgpu::{
+    Adapter, BindGroup, BindGroupLayout, Buffer, Device, Queue, RenderPipeline, Surface, Texture,
+};
+use winit::window::Window;
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+pub(crate) struct Voxelement {
+    pub(crate) albedo: [f32; 4],
+    pub(crate) content: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+pub(crate) struct SizedNode {
+    /// Composite field:
+    /// - Byte 1: Boolean value, true in case node is a leaf
+    /// - In case of internal nodes:
+    ///   - Byte 2: TBD
+    ///   - Byte 3: TBD
+    ///   - Byte 4: Lvl2 Occupancy bitmap
+    /// - In case of leaf nodes:
+    ///   - Byte 2: TBD
+    ///   - Byte 3: TBD
+    ///   - Byte 4: TBD
+    pub(crate) sized_node_meta: u32,
+
+    /// index of where the data about this node is found in children_buffer
+    /// - In case of internal nodes:
+    ///   - 8 Index value of node children
+    /// - In case of leaf nodes:
+    ///   - Byte 1-4: Occupancy bitmap MSB
+    ///   - Byte 5-8: Occupancy bitmap LSB
+    ///   - Byte 9-12: TBD
+    ///   - Byte 13-16: TBD
+    ///   - Byte 17-20: TBD
+    ///   - Byte 21-24: TBD
+    ///   - Byte 25-28: TBD
+    ///   - Byte 29-32: TBD
+    pub(crate) children_start_at: u32,
+
+    /// index of where the voxel values contained in the node start inside the voxels buffer,
+    /// or a "none_value". Should the field contain an index, the next voxel_brick_dim^3 elements
+    /// inside the @voxels array count as part of the voxels associated with the node
+    pub(crate) voxels_start_at: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+pub struct OctreeMetaData {
+    pub(crate) octree_size: u32,
+    pub(crate) voxel_brick_dim: u32,
+    pub ambient_light_color: [f32; 3],
+    pub ambient_light_position: [f32; 3],
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable, PartialEq)]
+pub struct Viewport {
+    pub origin: [f32; 3],
+    pub direction: [f32; 3],
+    pub size: [f32; 2],
+    pub fov: f32,
+}
+
+impl Default for Viewport {
+    fn default() -> Self {
+        Self {
+            origin: [0., 0., -1.],
+            direction: [0., 0., 1.],
+            size: [1.5, 1.],
+            fov: 45.,
+        }
+    }
+}
+
+#[derive(Default)] //TODO: This isn't good to be exposed
+pub struct SvxRenderApp {
+    //render data and parameters
+    pub(crate) output_width: u32,
+    pub(crate) output_height: u32,
+    pub(crate) texture_extent: wgpu::Extent3d,
+    pub viewport: Viewport,
+
+    // wgpu pipeline
+    pub(crate) wgpu_instance: wgpu::Instance,
+    pub(crate) adapter: Option<Adapter>,
+    pub(crate) window: Option<Arc<Window>>,
+    pub(crate) surface: Option<Surface<'static>>,
+    pub(crate) device: Option<Device>,
+    pub(crate) pipeline: Option<RenderPipeline>,
+    pub(crate) queue: Option<Queue>,
+    //layouts, textures and buffers
+    pub(crate) dynamic_group: Option<BindGroup>,
+    pub(crate) tree_group: Option<BindGroup>,
+    pub(crate) output_texture: Option<Texture>,
+    pub(crate) output_texture_render: Option<Texture>,
+    pub(crate) viewport_buffer: Option<Buffer>,
+    // pub(crate) metadata_buffer: Option<Buffer>,
+    // pub(crate) nodes_buffer: Option<Buffer>,
+    // pub(crate) children_buffer: Option<Buffer>,
+    // pub(crate) voxels_buffer: Option<Buffer>,
+}

--- a/src/octree/tests.rs
+++ b/src/octree/tests.rs
@@ -1,4 +1,41 @@
 #[cfg(test)]
+mod types_byte_compatibility {
+    use crate::octree::Albedo;
+    use encase::{ShaderType, StorageBuffer};
+
+    #[test]
+    fn albedo_size_is_as_expected() {
+        const SIZE: usize = std::mem::size_of::<Albedo>();
+        const EXPECTED_SIZE: usize = 4 * std::mem::size_of::<f32>();
+        assert_eq!(
+            SIZE, EXPECTED_SIZE,
+            "RGBA should be {} bytes wide but was {}",
+            EXPECTED_SIZE, SIZE
+        );
+    }
+
+    #[test]
+    fn test_wgpu_compatibility() {
+        Albedo::assert_uniform_compat();
+    }
+
+    #[test]
+    fn test_buffer_readback() {
+        let original_value = Albedo::default()
+            .with_red(1.)
+            .with_blue(0.5)
+            .with_alpha(0.6);
+        let mut buffer = StorageBuffer::new(Vec::<u8>::new());
+        buffer.write(&original_value).unwrap();
+        let mut byte_buffer = buffer.into_inner();
+        let buffer = StorageBuffer::new(&mut byte_buffer);
+        let mut value = Albedo::default();
+        buffer.read(&mut value).unwrap();
+        assert_eq!(value, original_value);
+    }
+}
+
+#[cfg(test)]
 mod octree_serialization_tests {
     use crate::octree::types::Albedo;
     use bendy::decoding::FromBencode;

--- a/src/octree/types.rs
+++ b/src/octree/types.rs
@@ -69,10 +69,10 @@ impl VoxelData for Albedo {
     }
 
     fn clear(&mut self) {
-        self.r = 0;
-        self.r = 0;
-        self.b = 0;
-        self.a = 0;
+        self.r = 0.;
+        self.r = 0.;
+        self.b = 0.;
+        self.a = 0.;
     }
 }
 
@@ -84,10 +84,10 @@ impl From<u32> for Albedo {
         let r = ((value & 0xFF000000) >> 24) as u8;
 
         Albedo::default()
-            .with_red(r)
-            .with_green(g)
-            .with_blue(b)
-            .with_alpha(a)
+            .with_red(r as f32 / 255.)
+            .with_green(g as f32 / 255.)
+            .with_blue(b as f32 / 255.)
+            .with_alpha(a as f32 / 255.)
     }
 }
 
@@ -103,47 +103,37 @@ pub struct Octree<T: Default + Clone + VoxelData, const DIM: usize = 1> {
     pub(in crate::octree) node_children: Vec<NodeChildren<u32>>, // Children index values of each Node
 }
 
+#[cfg_attr(feature = "wgpu", derive(encase::ShaderType))]
 #[derive(Default, Clone, Copy, Debug, PartialEq)]
 pub struct Albedo {
-    pub r: u8,
-    pub g: u8,
-    pub b: u8,
-    pub a: u8,
+    pub r: f32,
+    pub g: f32,
+    pub b: f32,
+    pub a: f32,
 }
 
 impl Albedo {
-    pub fn with_red(mut self, r: u8) -> Self {
+    pub fn with_red(mut self, r: f32) -> Self {
         self.r = r;
         self
     }
 
-    pub fn with_green(mut self, g: u8) -> Self {
+    pub fn with_green(mut self, g: f32) -> Self {
         self.g = g;
         self
     }
 
-    pub fn with_blue(mut self, b: u8) -> Self {
+    pub fn with_blue(mut self, b: f32) -> Self {
         self.b = b;
         self
     }
 
-    pub fn with_alpha(mut self, a: u8) -> Self {
+    pub fn with_alpha(mut self, a: f32) -> Self {
         self.a = a;
         self
     }
 
     pub fn is_transparent(&self) -> bool {
-        self.a == 0
+        self.a == 0.0
     }
-}
-
-#[test]
-fn albedo_size_is_4_bytes() {
-    const SIZE: usize = std::mem::size_of::<Albedo>();
-    const EXPECTED_SIZE: usize = 4;
-    assert_eq!(
-        SIZE, EXPECTED_SIZE,
-        "RGBA should be {} bytes wide but was {}",
-        EXPECTED_SIZE, SIZE
-    );
 }

--- a/src/spatial/math/tests.rs
+++ b/src/spatial/math/tests.rs
@@ -1,5 +1,5 @@
-#[cfg(feature = "raytracing")]
 #[cfg(test)]
+#[cfg(feature = "raytracing")]
 mod intersection_tests {
 
     use crate::spatial::{
@@ -63,5 +63,24 @@ mod intersection_tests {
         assert!(V3c::new(0., 0., -1.) == cube_impact_normal(&cube, &V3c::new(1., 1., 0.)));
         assert!(V3c::new(0., -1., 0.) == cube_impact_normal(&cube, &V3c::new(1., 0., 1.)));
         assert!(V3c::new(-1., 0., 0.) == cube_impact_normal(&cube, &V3c::new(0., 1., 1.)));
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "wgpu")]
+mod wgpu_tests {
+    use crate::spatial::math::vector::V3cf32;
+    use encase::StorageBuffer;
+
+    #[test]
+    fn test_buffer_readback() {
+        let original_value = V3cf32::new(0.666, 0.69, 420.0);
+        let mut buffer = StorageBuffer::new(Vec::<u8>::new());
+        buffer.write(&original_value).unwrap();
+        let mut byte_buffer = buffer.into_inner();
+        let buffer = StorageBuffer::new(&mut byte_buffer);
+        let mut value = V3cf32::default();
+        buffer.read(&mut value).unwrap();
+        assert_eq!(value, original_value);
     }
 }

--- a/src/spatial/math/vector.rs
+++ b/src/spatial/math/vector.rs
@@ -3,11 +3,14 @@
     feature = "serialization",
     derive(serde::Serialize, serde::Deserialize)
 )]
+#[repr(C)]
 pub struct V3c<T> {
     pub x: T,
     pub y: T,
     pub z: T,
 }
+
+pub type V3cf32 = V3c<f32>;
 
 impl<T: Copy> V3c<T> {
     pub fn new(x: T, y: T, z: T) -> Self {
@@ -189,6 +192,14 @@ impl From<V3c<u32>> for V3c<f32> {
     }
 }
 
+impl From<[f32; 3]> for V3c<f32> {
+    fn from(vec: [f32; 3]) -> V3c<f32> {
+        {
+            V3c::new(vec[0], vec[1], vec[2])
+        }
+    }
+}
+
 impl From<V3c<u32>> for V3c<usize> {
     fn from(vec: V3c<u32>) -> V3c<usize> {
         {
@@ -250,5 +261,25 @@ impl From<V3c<i32>> for V3c<u32> {
         {
             V3c::new(vec.x as u32, vec.y as u32, vec.z as u32)
         }
+    }
+}
+
+#[cfg(feature = "wgpu")]
+use encase::{impl_vector, vector::AsMutVectorParts, vector::AsRefVectorParts};
+
+#[cfg(feature = "wgpu")]
+impl_vector!(3, V3cf32, f32; using From);
+
+#[cfg(feature = "wgpu")]
+impl AsRefVectorParts<f32, 3> for V3cf32 {
+    fn as_ref_parts(&self) -> &[f32; 3] {
+        unsafe { &*(self as *const V3cf32 as *const [f32; 3]) }
+    }
+}
+
+#[cfg(feature = "wgpu")]
+impl AsMutVectorParts<f32, 3> for V3cf32 {
+    fn as_mut_parts(&mut self) -> &mut [f32; 3] {
+        unsafe { &mut *(self as *mut V3cf32 as *mut [f32; 3]) }
     }
 }


### PR DESCRIPTION
To have more control over the pipeline wrt multiple rendering passes and rendering to a texture, a raw wgpu pipeline is introduced. 

Remaining TODOs: 
 - [ ] Execute compute shader
 - [ ] Display compute shader output in Fragment shader
 - [ ] Register tree binding group to pipeline
   - [ ] Finalize API for uploading octree to SvxRenderApp
   - [ ] Verify if data is being correctly uploaded
 - [ ] Re-structure `SvxRenderApp` - from a tangled Option mess into a reasonable architecture
 - [ ] Implement explicit Albedo support for wgpu::Color
 - [ ] remove default_image pixels update (only for test purposes)
 - [ ] Application crashes when window is too small
 - [ ] Write documentation to ney types, functions etc..
 - [ ] try to support web adapter
   - [ ] try to discard TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES - https://www.reddit.com/r/wgpu/comments/x5z4tb/writing_to_a_texture_from_a_compute_shader/
   - [ ] try to support downlevel_webgl2_defaults instead of downlevel_defaults